### PR TITLE
Change lua callback to match Lua playground

### DIFF
--- a/array-base64-pcre/filter.lua
+++ b/array-base64-pcre/filter.lua
@@ -63,7 +63,7 @@ local function add_calculated_fields(tag, timestamp, record)
   table.insert(record.tag3, { key1 = 'value9', key2 = 'value10'})
 end
 
-function process_record(tag, timestamp, record)
+function cb_filter(tag, timestamp, record)
   base64_encode(tag, timestamp, record)
   parse_fields(tag, timestamp, record)
   add_calculated_fields(tag, timestamp, record)

--- a/crypto-hash/filter.lua
+++ b/crypto-hash/filter.lua
@@ -21,7 +21,7 @@ local md5 = digest_factory('md5')
 local sha1 = digest_factory('sha1')
 local sha256 = digest_factory('sha256')
 
-function process_record(tag, timestamp, record)
+function cb_filter(tag, timestamp, record)
   record.md5 = md5(record.log)
   record.sha1 = sha1(record.log)
   record.sha256 = sha256(record.log)

--- a/flb.conf
+++ b/flb.conf
@@ -17,7 +17,7 @@
     Name    lua
     Match   *
     script  filter.lua
-    call    process_record
+    call    cb_filter
 
 [OUTPUT]
     name stdout

--- a/xml-parsing/filter.lua
+++ b/xml-parsing/filter.lua
@@ -73,7 +73,7 @@ end
 
 local parser = create_parser('event')
 
-function process_record(tag, timestamp, record)
+function cb_filter(tag, timestamp, record)
   local result = parser:parse(record.log)
   if result then
     -- fully parsed record


### PR DESCRIPTION
I'm changing the "process_record" callback name to "cb_filter" which matches the standard used by the Lua playground. The goal is to integrate these samples with the playground UI, so ideally we'd have samples that just work on the playground.

Signed-off-by: Thiago Padilha <thiago@calyptia.com>